### PR TITLE
[1.x] Remove call static

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -7,7 +7,7 @@ namespace Piscibus\PhpHashtag;
 class Extractor
 {
     /**
-     * Extract the hashtag from a string.
+     * Extracts the hashtags from a string.
      */
     public static function extract(string $text): array
     {
@@ -19,13 +19,5 @@ class Extractor
         }
 
         return $hashtags;
-    }
-
-    /**
-     * Enable static calls.
-     */
-    public static function __callStatic(string $name, array $arguments)
-    {
-        return static::$name($arguments);
     }
 }

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -2,14 +2,11 @@
 
 declare(strict_types=1);
 
+use Piscibus\PhpHashtag\Extractor;
 use function PHPUnit\Framework\assertEquals;
 
-use Piscibus\PhpHashtag\Extractor;
-
 test('extract with english text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract(
+    $actual = Extractor::extract(
         'This is a #test and another #test2 and #foo_bar and #FooBar and #foo@bar #__ #foo__bar #2023 #👋 #foo_👋'
     );
 
@@ -20,9 +17,7 @@ test('extract with english text', function () {
 });
 
 test('extract with arabic text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract('هذا هو #تجربة و #تجربة2 و #foo_bar و #FooBar و #foo و #كلمة_و_أخرى');
+    $actual = Extractor::extract('هذا هو #تجربة و #تجربة2 و #foo_bar و #FooBar و #foo و #كلمة_و_أخرى');
 
     assertEquals(
         ['#تجربة', '#تجربة2', '#foo_bar', '#FooBar', '#foo', '#كلمة_و_أخرى'],
@@ -31,9 +26,7 @@ test('extract with arabic text', function () {
 });
 
 test('extract with french text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract('Ceci est un #test et un autre #test2 et #foo_bar et #FooBar et #foo et #superposés');
+    $actual = Extractor::extract('Ceci est un #test et un autre #test2 et #foo_bar et #FooBar et #foo et #superposés');
 
     assertEquals(
         ['#test', '#test2', '#foo_bar', '#FooBar', '#foo', '#superposés'],
@@ -42,9 +35,7 @@ test('extract with french text', function () {
 });
 
 test('extract with german text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract(
+    $actual = Extractor::extract(
         'Dies ist ein #test und ein anderer #test2 und #foo_bar und #FooBar und #foo und #überlappend'
     );
 
@@ -55,9 +46,7 @@ test('extract with german text', function () {
 });
 
 test('extract with turkish text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract('Bu bir #test ve başka bir #test2 ve #foo_bar ve #FooBar ve #foo ve #üstüste');
+    $actual = Extractor::extract('Bu bir #test ve başka bir #test2 ve #foo_bar ve #FooBar ve #foo ve #üstüste');
 
     assertEquals(
         ['#test', '#test2', '#foo_bar', '#FooBar', '#foo', '#üstüste'],
@@ -66,20 +55,10 @@ test('extract with turkish text', function () {
 });
 
 test('extract with spanish text', function () {
-    $sut = new Extractor();
-
-    $actual = $sut->extract('Esto es un #test y otro #test2 y #foo_bar y #FooBar y #foo y #superpuestos');
+    $actual = Extractor::extract('Esto es un #test y otro #test2 y #foo_bar y #FooBar y #foo y #superpuestos');
 
     assertEquals(
         ['#test', '#test2', '#foo_bar', '#FooBar', '#foo', '#superpuestos'],
-        $actual
-    );
-});
-
-test('call statically', function () {
-    $actual = Extractor::extract('calling this #method #statically');
-    assertEquals(
-        ['#method', '#statically'],
         $actual
     );
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Piscibus\PhpHashtag\Tests;
-
-class TestCase extends \PHPUnit\Framework\TestCase
-{
-}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | main <!-- see below -->                                             |
| Bug fix?      | no                                                             |
| New feature?  | yes/no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

As per the title, this PR removes the no longer needed `__callStatic` method.
