### PR TITLE
fix: remove unnecessary loop

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -8,16 +8,13 @@ class Extractor
 {
     /**
      * Extracts the hashtags from a string.
+     *
+     * @return array<string>
      */
     public static function extract(string $text): array
     {
-        $hashtags = [];
         preg_match_all('/(#[\p{L}\d_]+)/u', $text, $matches);
 
-        foreach ($matches[0] as $match) {
-            $hashtags[] = $match;
-        }
-
-        return $hashtags;
+        return $matches[0];
     }
 }


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| License       | MIT                                                                |

I just noticed that we are looping on matches and we can return them instantly. 
